### PR TITLE
`git log` や `git rev-parse` ができない場合でも通知に commit message が表示されるようにしたい

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,15 +19,15 @@ runs:
           echo "STATUS_TEXT=Failure"  >> $GITHUB_ENV
         fi
         if [ "${{ github.event_name }}" = "pull_request" ]; then
-          head_sha=$(git rev-parse --short=8 ${{ github.event.pull_request.head.sha }})
-          echo "COMMIT_SHA=$head_sha"                    >> $GITHUB_ENV
-          echo "COMMIT_MESSAGE<<EOF"                     >> $GITHUB_ENV
-          echo "$(git log --format=%B -n 1 $head_sha)"   >> $GITHUB_ENV
-          echo "EOF"                                     >> $GITHUB_ENV
+          head_sha=$(echo "${{ github.event.pull_request.head.sha }}" | head -c8)
+          echo "COMMIT_SHA=$head_sha"                   >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE<<EOF"                    >> $GITHUB_ENV
+          echo "${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+          echo "EOF"                                    >> $GITHUB_ENV
           echo "COMMIT_URL=${{ github.event.pull_request.html_url }}"   >> $GITHUB_ENV
           echo "COMMIT_LINK=${{github.repository}}#${{github.event.pull_request.number}}" >> $GITHUB_ENV
         else
-          head_sha=$(git rev-parse --short=8 ${{ github.sha }})
+          head_sha=$(echo "${{ github.sha }}" | head -c8)
           echo "COMMIT_SHA=$head_sha"                    >> $GITHUB_ENV
           echo "COMMIT_MESSAGE<<EOF"                     >> $GITHUB_ENV
           echo "${{ github.event.head_commit.message }}" >> $GITHUB_ENV


### PR DESCRIPTION
## やりたいこと

対応してる Git が入ってない環境がある場合 `git log` や `git rev-parse` ができない場合があるので、その場合でもコミットが取得できるようにしてたい。

> The repository will be downloaded using the GitHub REST API
> To create a local Git repository instead, add Git 2.18 or higher to the PATH


https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-example-33

<img width="865" alt="image" src="https://user-images.githubusercontent.com/6015450/136664125-08714419-48d1-4980-a7b8-c26c6e4d6e16.png">

Test out new idobata notify without relying on git to get commit on PR https://github.com/yasslab/yasslab.jp/pull/572